### PR TITLE
Add retry and recall script

### DIFF
--- a/neurio.py
+++ b/neurio.py
@@ -45,6 +45,9 @@ pvdate = strftime('%Y%m%d')
 #status TIME  24 HH:MM
 pvtime = strftime('%H:%M')
 
+#set retries to 5
+requests.adapters.HTTPAdapter(max_retries=5)
+
 #pull json from local neurio sensor json
 pvdata = requests.get('http://'+neurioip+'/current-sample').json()
 
@@ -75,7 +78,7 @@ else:
 	fd.close()
 
 #upload the data to the pvoutput website  d=date t=time v2=Power_gen_watts v3=Power_consumed_watts v5=temp_celcius v6=genation volts
-cmd=('curl -d "d=' + pvdate + '" -d "t=' + pvtime + '" -d "v2=' + str(gen_W) + '" -d "v4=' + str(cons_W) + '" -d "v5=' + str(temp_c) + '" -d "v6=' + str(gen_V) + '" -H "X-Pvoutput-Apikey:'+ APIKEY +'" -H "X-Pvoutput-SystemId:'+ SYSTEMID +'" http://pvoutput.org/service/r2/addstatus.jsp') 
+cmd=('curl --retry 10 -d "d=' + pvdate + '" -d "t=' + pvtime + '" -d "v2=' + str(gen_W) + '" -d "v4=' + str(cons_W) + '" -d "v5=' + str(temp_c) + '" -d "v6=' + str(gen_V) + '" -H "X-Pvoutput-Apikey:'+ APIKEY +'" -H "X-Pvoutput-SystemId:'+ SYSTEMID +'" http://pvoutput.org/service/r2/addstatus.jsp') 
 
 #send the request
 ret = subprocess.call(cmd, shell=True)

--- a/recall.sh
+++ b/recall.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# Change this to your DIR
+DIR=~/neurio/
+
+usage() 
+{
+  echo "recall: -d DATE -t TIME"
+}
+
+while getopts "d:t:" arg; do
+  case $arg in 
+    d)
+      DATE=$OPTARG
+      ;;
+    t)
+      TIME=$OPTARG
+      ;;
+    *)
+      usage
+      exit;
+      ;;
+    esac
+done
+
+if [ -z "${DATE}" ] || [ -z "${TIME}" ]; then
+    usage
+    exit;
+fi
+
+
+FILE=$DIR$DATE.csv
+
+post() 
+{
+  RAW=$1
+#  echo $RAW
+  if [ -z "$RAW" ]; then
+    echo "No data"
+    exit;
+  fi
+
+  TIME=`echo $RAW|cut -d, -f1`
+  GEN_W=`echo $RAW|cut -d, -f2`
+  GEN_V=`echo $RAW|cut -d, -f3`
+  CON_W=`echo $RAW|cut -d, -f4`
+  TEMP=`echo $RAW|awk -F "," '{print $NF}' | sed -e 's/[[:space:]]*$//'`
+
+  echo "POSTING AS $DATE $TIME "
+#  curl -d "v4=$TEMP" -d "d=$DATE" -d "t=$TIME" -d "v2=$GEN_W" -d "v4=$CON_W" -d "v6=$GEN_V"  -H "X-Pvoutput-Apikey:6afa9ec13b0c9826654932ab8260088e1ad8826f" -H "X-Pvoutput-SystemId:50289" http://pvoutput.org/service/r2/addstatus.jsp
+  echo ""
+}
+
+
+echo "Reading from $FILE"
+RAW=`grep $TIME $FILE`
+post $RAW
+
+# API only allows 60 requests per hour, don't do this!
+#array=$(sed -n '2,$p' "$FILE")
+#for RAW in $array 
+#do
+#  post $RAW
+#done
+
+
+
+


### PR DESCRIPTION
Outline
---
Adding retries to ``curl`` and ``python requests``.  Also, I wrote a simple shell script to repost data in case of failure.

Detail
---
``recall.sh`` uses the file saved by python and repost data based on given date and time.  

The syntax looks like this:

```shell
recall.sh -d 20130303 -t 13:45
```